### PR TITLE
Add benchmark name to json output

### DIFF
--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -632,7 +632,10 @@ string InterpretedBenchmark::BenchmarkInfo() {
 string InterpretedBenchmark::GetLogOutput(BenchmarkState *state_p) {
 	auto &state = (InterpretedBenchmarkState &)*state_p;
 	auto &profiler = QueryProfiler::Get(*state.con.context);
-	return profiler.ToJSON();
+
+	map<string, string> info = {{"benchmark_name", DisplayName()}};
+
+	return profiler.ToExtendedJSON(info);
 }
 
 string InterpretedBenchmark::DisplayName() {

--- a/benchmark/ssb/ssb_benchmark.cpp
+++ b/benchmark/ssb/ssb_benchmark.cpp
@@ -30,6 +30,12 @@ using namespace duckdb;
 	}                                                                                                                  \
 	string VerifyResult(QueryResult *result) override {                                                                \
 		return "";                                                                                                     \
+	}                                                                                                                  \
+	string GetLogOutput(BenchmarkState *state_p) override {                                                            \
+		auto state = (DuckDBBenchmarkState *)state_p;                                                                  \
+		auto &profiler = QueryProfiler::Get(*state->conn.context);                                                     \
+		map<string, string> info = {{"benchmark_name", DisplayName()}};                                                \
+		return profiler.ToExtendedJSON(info);                                                                          \
 	}
 
 #define NORMAL_CONFIG                                                                                                  \

--- a/src/include/duckdb/main/query_profiler.hpp
+++ b/src/include/duckdb/main/query_profiler.hpp
@@ -152,6 +152,7 @@ public:
 	static string JSONSanitize(const string &text);
 	static string DrawPadded(const string &str, idx_t width);
 	DUCKDB_API string ToJSON() const;
+	DUCKDB_API string ToExtendedJSON(const map<string, string> &extra_fields) const;
 	DUCKDB_API void WriteToFile(const char *path, string &info) const;
 
 	idx_t OperatorSize() {

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -645,9 +645,18 @@ static string StringifyAndFree(yyjson_mut_doc *doc, yyjson_mut_val *object) {
 }
 
 string QueryProfiler::ToJSON() const {
+	map<string, string> no_extra_fields;
+	return ToExtendedJSON(no_extra_fields);
+}
+
+string QueryProfiler::ToExtendedJSON(const map<string, string> &extra_fields) const {
 	auto doc = yyjson_mut_doc_new(nullptr);
 	auto result_obj = yyjson_mut_obj(doc);
 	yyjson_mut_doc_set_root(doc, result_obj);
+
+	for (auto &key_value : extra_fields) {
+	 	yyjson_mut_obj_add_str(doc, result_obj, key_value.first.c_str(), key_value.second.c_str());
+	}
 
 	if (!IsEnabled()) {
 		yyjson_mut_obj_add_str(doc, result_obj, "result", "disabled");


### PR DESCRIPTION

- **Patch interpreted benchmark output to include benchmark info**
- **Allow for extra fields in profiler JSON output**
- **Override the GetLogOutput and use the exented json generator**
